### PR TITLE
generate config for jekyll docs

### DIFF
--- a/docs/classes/_component_.component.html
+++ b/docs/classes/_component_.component.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">__component<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> =&nbsp;true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/component.ts#L3">component.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/component.ts#L3">component.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/_component_map_.componentmap.html
+++ b/docs/classes/_component_map_.componentmap.html
@@ -112,7 +112,7 @@
 					<div class="tsd-signature tsd-kind-icon">map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol">, </span><a href="_component_.component.html" class="tsd-signature-type">Component</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;new Map&lt;Constructor&lt;Component&gt;, Component&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/component-map.ts#L5">component-map.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/component-map.ts#L5">component-map.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/component-map.ts#L21">component-map.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/component-map.ts#L21">component-map.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -149,7 +149,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/component-map.ts#L7">component-map.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/component-map.ts#L7">component-map.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -181,7 +181,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/component-map.ts#L17">component-map.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/component-map.ts#L17">component-map.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/component-map.ts#L13">component-map.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/component-map.ts#L13">component-map.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/classes/_entity_.entity.html
+++ b/docs/classes/_entity_.entity.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/entity.ts#L7">entity.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/entity.ts#L7">entity.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <a href="../modules/_entity_.html#entityid" class="tsd-signature-type">EntityId</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/entity.ts#L9">entity.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/entity.ts#L9">entity.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/entity.ts#L7">entity.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/entity.ts#L7">entity.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/_system_.system.html
+++ b/docs/classes/_system_.system.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/system.ts#L12">system.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/system.ts#L12">system.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_world_.world.html
+++ b/docs/classes/_world_.world.html
@@ -131,7 +131,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L28">world.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L28">world.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -163,7 +163,7 @@
 					<div class="tsd-signature tsd-kind-icon">entities<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="_entity_.entity.html" class="tsd-signature-type">Entity</a><span class="tsd-signature-symbol">, </span><a href="_component_map_.componentmap.html" class="tsd-signature-type">ComponentMap</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;new Map()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L28">world.ts:28</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L28">world.ts:28</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -173,7 +173,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<wbr>Generator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L34">world.ts:34</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L34">world.ts:34</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">systems<span class="tsd-signature-symbol">:</span> <a href="_system_.system.html" class="tsd-signature-type">System</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L25">world.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L25">world.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -198,7 +198,7 @@
 					<div class="tsd-signature tsd-kind-icon">systems<wbr>ToAdd<span class="tsd-signature-symbol">:</span> <a href="_system_.system.html" class="tsd-signature-type">System</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L27">world.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L27">world.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -208,7 +208,7 @@
 					<div class="tsd-signature tsd-kind-icon">systems<wbr>ToRemove<span class="tsd-signature-symbol">:</span> <a href="_system_.system.html" class="tsd-signature-type">System</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L26">world.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L26">world.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -225,7 +225,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L50">world.ts:50</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L50">world.ts:50</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L73">world.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L73">world.ts:73</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -282,7 +282,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L46">world.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L46">world.ts:46</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_entity_.entity.html" class="tsd-signature-type">Entity</a></h4>
@@ -299,7 +299,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L81">world.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L81">world.ts:81</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -330,7 +330,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L40">world.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L40">world.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -361,7 +361,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L85">world.ts:85</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L85">world.ts:85</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -384,7 +384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L109">world.ts:109</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L109">world.ts:109</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/config.yml
+++ b/docs/config.yml
@@ -1,0 +1,4 @@
+# Used to configure jekyll for typedoc
+include:
+  - '_*_.html'
+  - '_*_.*.html'

--- a/docs/modules/_entity_.html
+++ b/docs/modules/_entity_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">Entity<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/entity.ts#L1">entity.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/entity.ts#L1">entity.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_world_.html
+++ b/docs/modules/_world_.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Constructor&lt;T, Arguments&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L8">world.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L8">world.ts:8</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/10a0e21/src/world.ts#L12">world.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/ec1e1a7/src/world.ts#L12">world.ts:12</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/jekyll.config.yml
+++ b/jekyll.config.yml
@@ -1,0 +1,4 @@
+# Used to configure jekyll for typedoc
+include:
+  - '_*_.html'
+  - '_*_.*.html'

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "benchmark": "ts-node --project tsconfig.benchmark.json benchmark/world-view.ts",
     "docs": "typedoc --out docs --exclude \"**/*+(index|.test|.spec|.e2e).ts\" src/",
+    "postdocs": "cp jekyll.config.yml docs/config.yml",
     "lint": "tslint --project .",
     "prebuild": "yarn run clean",
     "build": "yarn run lint && tsc",


### PR DESCRIPTION
Kept getting 404 errors on the classes exported. Trying the fix noted in https://github.com/TypeStrong/typedoc/issues/620#issuecomment-437636828