### PR TITLE
Improve component map speed

### DIFF
--- a/docs/classes/_component_.component.html
+++ b/docs/classes/_component_.component.html
@@ -106,7 +106,7 @@
 					<div class="tsd-signature tsd-kind-icon">__component<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">true</span><span class="tsd-signature-symbol"> =&nbsp;true</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L27">component.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L27">component.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -116,7 +116,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bitmask<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BitSet</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> =&nbsp;null</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L24">component.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L24">component.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -126,7 +126,7 @@
 					<div class="tsd-signature tsd-kind-icon">_bitmask<wbr>Generator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">BitSet</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;bitmaskGenerator()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L23">component.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L23">component.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -143,7 +143,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L29">component.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L29">component.ts:29</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">BitSet</span></h4>

--- a/docs/classes/_component_map_.componentmap.html
+++ b/docs/classes/_component_map_.componentmap.html
@@ -115,7 +115,7 @@
 					<div class="tsd-signature tsd-kind-icon">bitmask<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BitSet</span><span class="tsd-signature-symbol"> =&nbsp;new BitSet(0)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L5">component-map.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L5">component-map.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -125,7 +125,7 @@
 					<div class="tsd-signature tsd-kind-icon">map<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> &amp; </span><a href="../interfaces/_component_.icomponent.html" class="tsd-signature-type">IComponent</a><span class="tsd-signature-symbol">, </span><a href="_component_.component.html" class="tsd-signature-type">Component</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;new Map&lt;ComponentConstructor, Component&gt;()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L6">component-map.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L6">component-map.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -142,7 +142,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L34">component-map.ts:34</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L52">component-map.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
@@ -162,7 +162,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L8">component-map.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L8">component-map.ts:8</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -194,7 +194,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L30">component-map.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L48">component-map.ts:48</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -217,7 +217,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L26">component-map.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L44">component-map.ts:44</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">object</span><span class="tsd-signature-symbol"> &amp; </span><a href="../interfaces/_component_.icomponent.html" class="tsd-signature-type">IComponent</a><span class="tsd-signature-symbol">&gt;</span></h4>
@@ -228,19 +228,19 @@
 					<a name="remove" class="tsd-anchor"></a>
 					<h3>remove</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">remove<span class="tsd-signature-symbol">(</span>componentCtor<span class="tsd-signature-symbol">: </span><a href="../modules/_component_.html#componentconstructor" class="tsd-signature-type">ComponentConstructor</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">remove<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>componentCtors<span class="tsd-signature-symbol">: </span><a href="../modules/_component_.html#componentconstructor" class="tsd-signature-type">ComponentConstructor</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L21">component-map.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L30">component-map.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>componentCtor: <a href="../modules/_component_.html#componentconstructor" class="tsd-signature-type">ComponentConstructor</a></h5>
+									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>componentCtors: <a href="../modules/_component_.html#componentconstructor" class="tsd-signature-type">ComponentConstructor</a><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -251,19 +251,19 @@
 					<a name="set" class="tsd-anchor"></a>
 					<h3>set</h3>
 					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
-						<li class="tsd-signature tsd-kind-icon">set<span class="tsd-signature-symbol">(</span>component<span class="tsd-signature-symbol">: </span><a href="_component_.component.html" class="tsd-signature-type">Component</a><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+						<li class="tsd-signature tsd-kind-icon">set<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>components<span class="tsd-signature-symbol">: </span><a href="_component_.component.html" class="tsd-signature-type">Component</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
 					</ul>
 					<ul class="tsd-descriptions">
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component-map.ts#L14">component-map.ts:14</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component-map.ts#L14">component-map.ts:14</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
 							<ul class="tsd-parameters">
 								<li>
-									<h5>component: <a href="_component_.component.html" class="tsd-signature-type">Component</a></h5>
+									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>components: <a href="_component_.component.html" class="tsd-signature-type">Component</a><span class="tsd-signature-symbol">[]</span></h5>
 								</li>
 							</ul>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>

--- a/docs/classes/_entity_.entity.html
+++ b/docs/classes/_entity_.entity.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/entity.ts#L7">entity.ts:7</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/entity.ts#L7">entity.ts:7</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -138,7 +138,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <a href="../modules/_entity_.html#entityid" class="tsd-signature-type">EntityId</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/entity.ts#L9">entity.ts:9</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/entity.ts#L9">entity.ts:9</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -148,7 +148,7 @@
 					<div class="tsd-signature tsd-kind-icon">version<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> =&nbsp;0</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/entity.ts#L7">entity.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/entity.ts#L7">entity.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/classes/_system_.system.html
+++ b/docs/classes/_system_.system.html
@@ -109,7 +109,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/system.ts#L12">system.ts:12</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/system.ts#L12">system.ts:12</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/_world_.world.html
+++ b/docs/classes/_world_.world.html
@@ -135,7 +135,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L27">world.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L27">world.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 					<div class="tsd-signature tsd-kind-icon">component<wbr>Entities<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="../modules/_component_.html#componentconstructor" class="tsd-signature-type">ComponentConstructor</a><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Set</span><span class="tsd-signature-symbol">&lt;</span><a href="_entity_.entity.html" class="tsd-signature-type">Entity</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;new Map()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L27">world.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L27">world.ts:27</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -177,7 +177,7 @@
 					<div class="tsd-signature tsd-kind-icon">entities<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><a href="_entity_.entity.html" class="tsd-signature-type">Entity</a><span class="tsd-signature-symbol">, </span><a href="_component_map_.componentmap.html" class="tsd-signature-type">ComponentMap</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> =&nbsp;new Map()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L26">world.ts:26</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L26">world.ts:26</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -187,7 +187,7 @@
 					<div class="tsd-signature tsd-kind-icon">id<wbr>Generator<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L33">world.ts:33</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L33">world.ts:33</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -202,7 +202,7 @@
 					<div class="tsd-signature tsd-kind-icon">systems<span class="tsd-signature-symbol">:</span> <a href="_system_.system.html" class="tsd-signature-type">System</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L23">world.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L23">world.ts:23</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -212,7 +212,7 @@
 					<div class="tsd-signature tsd-kind-icon">systems<wbr>ToAdd<span class="tsd-signature-symbol">:</span> <a href="_system_.system.html" class="tsd-signature-type">System</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L25">world.ts:25</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L25">world.ts:25</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -222,7 +222,7 @@
 					<div class="tsd-signature tsd-kind-icon">systems<wbr>ToRemove<span class="tsd-signature-symbol">:</span> <a href="_system_.system.html" class="tsd-signature-type">System</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> =&nbsp;[]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L24">world.ts:24</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L24">world.ts:24</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -239,7 +239,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L94">world.ts:94</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L94">world.ts:94</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L145">world.ts:145</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L147">world.ts:147</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -296,7 +296,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L45">world.ts:45</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L45">world.ts:45</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_entity_.entity.html" class="tsd-signature-type">Entity</a></h4>
@@ -313,7 +313,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L52">world.ts:52</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L52">world.ts:52</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -339,7 +339,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L115">world.ts:115</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L115">world.ts:115</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L119">world.ts:119</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L119">world.ts:119</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -391,7 +391,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L153">world.ts:153</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L155">world.ts:155</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -422,7 +422,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L39">world.ts:39</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L39">world.ts:39</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -453,7 +453,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L157">world.ts:157</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L159">world.ts:159</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -476,7 +476,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L181">world.ts:181</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L183">world.ts:183</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,11 +76,12 @@
 Kernel: <span class="hljs-number">4.19</span><span class="hljs-number">.57</span>-microsoft-standard
 CPU: Intel i7<span class="hljs-number">-4710</span>HQ (<span class="hljs-number">8</span>) @ <span class="hljs-number">2.494</span>GHz
 Memory: <span class="hljs-number">16</span>GB</code></pre>
-				<a href="#node-1270" id="node-1270" style="color: inherit; text-decoration: none;">
-					<h3>Node 12.7.0</h3>
+				<a href="#node-1280" id="node-1280" style="color: inherit; text-decoration: none;">
+					<h3>Node 12.8.0</h3>
 				</a>
 				<blockquote>
-					<p><code>World#view()</code> @ <code>100_000</code> entities with <code>100</code> components each x <code>x 31.10 ops/sec ±1.00%</code> (54 runs sampled)</p>
+					<p><code>World#view()</code> @ <code>100_000</code> entities with <code>100</code> components each x <code>1,213 ops/sec ±0.91%</code> (89 runs sampled)
+					<code>World#findEntity()</code> @ <code>100_000</code> entities with <code>100</code> components each x <code>2,119 ops/sec ±1.07%</code> (85 runs sampled)</p>
 				</blockquote>
 				<a href="#roadmap" id="roadmap" style="color: inherit; text-decoration: none;">
 					<h2>Roadmap</h2>

--- a/docs/interfaces/_component_.icomponent.html
+++ b/docs/interfaces/_component_.icomponent.html
@@ -98,7 +98,7 @@
 					<div class="tsd-signature tsd-kind-icon">bitmask<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">BitSet</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L17">component.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L17">component.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_component_.html
+++ b/docs/modules/_component_.html
@@ -105,7 +105,7 @@
 					<div class="tsd-signature tsd-kind-icon">Component<wbr>Constructor<span class="tsd-signature-symbol">:</span> <a href="_world_.html#constructor" class="tsd-signature-type">Constructor</a><span class="tsd-signature-symbol">&lt;</span><a href="../classes/_component_.component.html" class="tsd-signature-type">Component</a><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><a href="../interfaces/_component_.icomponent.html" class="tsd-signature-type">IComponent</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L20">component.ts:20</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L20">component.ts:20</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -122,7 +122,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/component.ts#L4">component.ts:4</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/component.ts#L4">component.ts:4</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">BitSet</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/docs/modules/_entity_.html
+++ b/docs/modules/_entity_.html
@@ -93,7 +93,7 @@
 					<div class="tsd-signature tsd-kind-icon">Entity<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/entity.ts#L1">entity.ts:1</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/entity.ts#L1">entity.ts:1</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/modules/_world_.html
+++ b/docs/modules/_world_.html
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">Constructor&lt;T, Arguments&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">object</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L6">world.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L6">world.ts:6</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/3a12b58/src/world.ts#L10">world.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/jakeklassen/ecs/blob/8c07f67/src/world.ts#L10">world.ts:10</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">IterableIterator</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">number</span><span class="tsd-signature-symbol">&gt;</span></h4>

--- a/src/component-map.ts
+++ b/src/component-map.ts
@@ -11,16 +11,34 @@ export class ComponentMap {
     return component != null ? (component as T) : undefined;
   }
 
-  public set(component: Component) {
-    this.map.set(component.constructor as ComponentConstructor, component);
-    this.bitmask = this.bitmask.or(
-      (component.constructor as (typeof Component)).bitmask,
-    );
+  public set(...components: Component[]) {
+    let mask = new BitSet(0);
+
+    for (const component of components) {
+      if (
+        this.map.has(component.constructor as ComponentConstructor) === false
+      ) {
+        mask = mask.or((component.constructor as ComponentConstructor).bitmask);
+      }
+
+      this.map.set(component.constructor as ComponentConstructor, component);
+    }
+
+    this.bitmask = this.bitmask.or(mask);
   }
 
-  public remove(componentCtor: ComponentConstructor) {
-    this.map.delete(componentCtor);
-    this.bitmask.flip(componentCtor.bitmask.msb());
+  public remove(...componentCtors: ComponentConstructor[]) {
+    let mask = new BitSet(0);
+
+    for (const componentCtor of componentCtors) {
+      if (this.map.has(componentCtor)) {
+        mask = mask.or(componentCtor.bitmask);
+      }
+
+      this.map.delete(componentCtor);
+    }
+
+    this.bitmask = this.bitmask.xor(mask);
   }
 
   public keys() {

--- a/src/world.ts
+++ b/src/world.ts
@@ -98,7 +98,7 @@ export class World {
     const entityComponents = this.entities.get(entity);
 
     if (entityComponents != null) {
-      components.forEach(component => entityComponents.set(component));
+      entityComponents.set(...components);
 
       for (const componentCtor of entityComponents.keys()) {
         if (this.componentEntities.has(componentCtor)) {
@@ -123,8 +123,10 @@ export class World {
     const entityComponents = this.entities.get(entity);
 
     if (entityComponents != null) {
-      components.forEach(component =>
-        entityComponents.remove(component.constructor as ComponentConstructor),
+      entityComponents.remove(
+        ...components.map(
+          component => component.constructor as ComponentConstructor,
+        ),
       );
 
       components.forEach(component => {


### PR DESCRIPTION
`yarn benchmark benchmark/component-map.ts`

ComponentMap on master

```
ComponentMap#set x 15,362 ops/sec ±0.88% (88 runs sampled)
ComponentMap#has x 41,779,221 ops/sec ±1.89% (84 runs sampled)
ComponentMap#get x 41,374,521 ops/sec ±2.38% (85 runs sampled)
ComponentMap#remove x 24,212 ops/sec ±0.97% (86 runs sampled)

Memory usage after benchmark
rss 327.73 MB
heapTotal 266.59 MB
heapUsed 233.68 MB
external 1.31 MB
```

PR benchmark

```
ComponentMap#set x 32,476 ops/sec ±0.40% (92 runs sampled)
ComponentMap#has x 43,388,250 ops/sec ±1.78% (88 runs sampled)
ComponentMap#get x 43,292,103 ops/sec ±1.49% (88 runs sampled)
ComponentMap#remove x 36,578 ops/sec ±0.43% (89 runs sampled)

Memory usage after benchmark
rss 205.05 MB
heapTotal 149.41 MB
heapUsed 129.82 MB
external 1.33 MB
```